### PR TITLE
Added ShowMapErrors parameter to BH config. In order to avoid spamming

### DIFF
--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -24,6 +24,7 @@ Maphack::Maphack() : Module("Maphack") {
 
 void Maphack::ReadConfig() {
 	revealType = (MaphackReveal)BH::config->ReadInt("RevealMode", 0);
+	showMapErrors = (MaphackReveal)BH::config->ReadInt("ShowMapErrors", 0);
 
 	Config automap(BH::config->ReadAssoc("Missile Color"));
 	automapColors["Player Missile"] = automap.ReadInt("Player", 0x97);
@@ -286,7 +287,9 @@ void Maphack::OnAutomapDraw() {
 						}
 					}
 				} else {
-					PrintText(1, "Unknown item code on map: %c%c%c\n", uInfo.itemCode[0], uInfo.itemCode[1], uInfo.itemCode[2]);
+					if (showMapErrors) {
+						PrintText(1, "Unknown item code on map: %c%c%c\n", uInfo.itemCode[0], uInfo.itemCode[1], uInfo.itemCode[2]);
+					}
 				}
 			}
 		}

--- a/BH/Modules/Maphack/Maphack.h
+++ b/BH/Modules/Maphack/Maphack.h
@@ -23,6 +23,7 @@ struct BaseSkill {
 class Maphack : public Module {
 	private:
 		unsigned int revealType;
+		unsigned int showMapErrors;
 		bool revealedGame, revealedAct[6], revealedLevel[255];
 		std::map<string, unsigned int> TextColorMap;
 		std::map<string, unsigned int> automapColors;


### PR DESCRIPTION
Added ShowMapErrors parameter to BH config. In order to avoid spamming with 'Unknown item code' error message in Modded game like MedianXL, Eastern Sun etc.